### PR TITLE
Add `pylint-ignore-paths` option, bump to `v1.1.0`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@ vX.X.X
 - Added `pylint-ignore-paths` input, passed to `pylint` via the
   `--ignore-paths` command-line argument.
 
+# Bug fixes
+
+- Usage errors thrown by the `pylint` invocation will now fail the
+  action.
+
 v1.0.0
 ------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Changes
 =======
 
-vX.X.X
+v1.1.0
 ------
 
 # New features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 Changes
 =======
 
+vX.X.X
+------
+
+# New features
+
+- Added `pylint-ignore-paths` input, passed to `pylint` via the
+  `--ignore-paths` command-line argument.
+
 v1.0.0
 ------
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Pylint configuration file location. Specifically, the value of
 Pylint checks to disable. Specifically, the value of `pylint`'s
 `--disable=` command-line option.
 
+## `pylint-ignore-paths`
+
+The paths to pass to `pylint`s `--ignore-paths` command-line option.
+
 ## Example usage
 ```yaml
 uses: TheFoundryVisionmongers/fn-pylint-action@v1

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   pylint-paths:
     description: "Paths to Python files"
     required: true
+  pylint-ignore-paths:
+    description: "Paths to ignore"
+    required: false
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ async function run() {
     const pylintDisable = core.getInput('pylint-disable') || "";
     const pylintRCFile = core.getInput('pylint-rcfile') || "";
     const pylintPaths = core.getInput('pylint-paths');
+    const pylintIgnorePaths = core.getInput('pylint-ignore-paths') || "";
 
     let pylintOutput = "";  // Pylint process output.
     try {
@@ -31,6 +32,7 @@ async function run() {
         // detected issues in the code that we need to report.
         await exec.exec("pylint", [
             `--disable=${pylintDisable}`,
+            `--ignore-paths=${pylintIgnorePaths}`,
             `--rcfile=${pylintRCFile}`,
             `--output-format=json`,
             ...pylintPaths.split(" ")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fn-pylint-action",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Run pylint as a GitHub action",
     "main": "dist/index.js",
     "scripts": {


### PR DESCRIPTION
Adds the ability to set the `--ignore-paths` command line option via the action, and fixes a bug that meant that a usage error didn't error the action.  Required by https://github.com/TheFoundryVisionmongers/OpenAssetIO/pull/152 and  [TheFoundryVisionmongers/OpenAssetIO/#152](https://github.com/TheFoundryVisionmongers/OpenAssetIO/issues/101).