### PR TITLE
[Action] Update to Node v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: "Paths to ignore"
     required: false
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
Use `node16` to avoid deprecation warnings.
