### PR TITLE
[Release] Bump version to 1.1.3 for release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,21 @@
 Changes
 =======
 
+v1.1.3
+------
+
+### Improvements
+
+- Bumped `node` version from `node12` to `node16`, in response to
+  deprecation warnings.
+
+v1.1.2
+------
+
+### Bug fixes
+
+- Bumped @actions/core from 1.6.0 to 1.9.1
+
 v1.1.1
 ------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "fn-pylint-action",
-    "version": "1.1.1",
+    "version": "1.1.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fn-pylint-action",
-    "version": "1.1.1",
+    "version": "1.1.3",
     "description": "Run pylint as a GitHub action",
     "main": "dist/index.js",
     "scripts": {


### PR DESCRIPTION
Prepare for release

Update version to 1.1.3, (we're skipping 1.1.2 in the release notes due to a mistake made when tagging last time.

Signed-off-by: Elliot Morris <elliot.morris@foundry.com>