### PR TITLE
Accept arbitrary Pylint args

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,31 +10,15 @@ It is assumed that `pylint` is already installed in the environment.
 
 ## Inputs
 
-## `pylint-paths`
+## `pylint-args`
 
-**Required** The paths to instruct `pylint` to scan, space-separated.
-
-## `pylint-rcfile`
-
-Pylint configuration file location. Specifically, the value of
-`pylint`'s `--rcfile=` command-line option.
-
-## `pylint-disable`
-
-Pylint checks to disable. Specifically, the value of `pylint`'s
-`--disable=` command-line option.
-
-## `pylint-ignore-paths`
-
-The paths to pass to `pylint`s `--ignore-paths` command-line option.
+**Required** The arguments to pass to `pylint`, as if on a command line.
 
 ## Example usage
 ```yaml
 uses: TheFoundryVisionmongers/fn-pylint-action@v1
 with:
-  pylint-disable: "C,I,R"  # Only errors and warnings.
-  pylint-rcfile: "./pyproject.toml"
-  pylint-paths: "python tests"
+  pylint-args: "--ignore=C,I,R --rcfile=pyproject.toml my_project tests"
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -1,18 +1,9 @@
 name: "Pylint"
 description: "Runs pylint and annotates a PR"
 inputs:
-  pylint-disable:
-    description: "Checks to disable"
-    required: false
-  pylint-rcfile:
-    description: "Config file for Pylint"
-    required: false
-  pylint-paths:
-    description: "Paths to Python files"
+  pylint-args:
+    description: "Arguments to pass to pylint"
     required: true
-  pylint-ignore-paths:
-    description: "Paths to ignore"
-    required: false
 runs:
   using: "node16"
   main: "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,59 +1,314 @@
 {
     "name": "fn-pylint-action",
-    "version": "1.1.3",
-    "lockfileVersion": 1,
+    "version": "2.0.0",
+    "lockfileVersion": 2,
     "requires": true,
-    "dependencies": {
-        "@actions/core": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-            "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
-            "requires": {
+    "packages": {
+        "": {
+            "name": "fn-pylint-action",
+            "version": "2.0.0",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@actions/core": "^1.9.1",
+                "@actions/exec": "^1.1.0",
+                "@actions/github": "^5.0.0",
+                "shell-quote": "^1.8.1"
+            },
+            "devDependencies": {
+                "@vercel/ncc": "*"
+            }
+        },
+        "node_modules/@actions/core": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
+            "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+            "dependencies": {
                 "@actions/http-client": "^2.0.1",
                 "uuid": "^8.3.2"
-            },
+            }
+        },
+        "node_modules/@actions/exec": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+            "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
             "dependencies": {
-                "@actions/http-client": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
-                    "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
-                    "requires": {
-                        "tunnel": "^0.0.6"
-                    }
+                "@actions/io": "^1.0.1"
+            }
+        },
+        "node_modules/@actions/github": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+            "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
+            "dependencies": {
+                "@actions/http-client": "^2.0.1",
+                "@octokit/core": "^3.6.0",
+                "@octokit/plugin-paginate-rest": "^2.17.0",
+                "@octokit/plugin-rest-endpoint-methods": "^5.13.0"
+            }
+        },
+        "node_modules/@actions/http-client": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.1.1.tgz",
+            "integrity": "sha512-qhrkRMB40bbbLo7gF+0vu+X+UawOvQQqNAA/5Unx774RS8poaOhThDOG6BGmxvAnxhQnDp2BG/ZUm65xZILTpw==",
+            "dependencies": {
+                "tunnel": "^0.0.6"
+            }
+        },
+        "node_modules/@actions/io": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+            "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
+        },
+        "node_modules/@octokit/auth-token": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+            "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+            "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+            "dependencies": {
+                "@octokit/auth-token": "^2.4.4",
+                "@octokit/graphql": "^4.5.8",
+                "@octokit/request": "^5.6.3",
+                "@octokit/request-error": "^2.0.5",
+                "@octokit/types": "^6.0.3",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "6.0.12",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+            "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+            "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+            "dependencies": {
+                "@octokit/request": "^5.6.0",
+                "@octokit/types": "^6.0.3",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "12.11.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+            "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "2.21.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+            "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+            "dependencies": {
+                "@octokit/types": "^6.40.0"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=2"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "5.16.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+            "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+            "dependencies": {
+                "@octokit/types": "^6.39.0",
+                "deprecation": "^2.3.1"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+            "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+            "dependencies": {
+                "@octokit/endpoint": "^6.0.1",
+                "@octokit/request-error": "^2.1.0",
+                "@octokit/types": "^6.16.1",
+                "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+            "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+            "dependencies": {
+                "@octokit/types": "^6.0.3",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "6.41.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+            "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+            "dependencies": {
+                "@octokit/openapi-types": "^12.11.0"
+            }
+        },
+        "node_modules/@vercel/ncc": {
+            "version": "0.38.0",
+            "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.0.tgz",
+            "integrity": "sha512-B4YKZMm/EqMptKSFyAq4q2SlgJe+VCmEH6Y8gf/E1pTlWbsUJpuH1ymik2Ex3aYO5mCWwV1kaSYHSQOT8+4vHA==",
+            "dev": true,
+            "bin": {
+                "ncc": "dist/ncc/cli.js"
+            }
+        },
+        "node_modules/before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+        },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+        },
+        "node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
                 }
             }
         },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/shell-quote": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+            "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "node_modules/tunnel": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+            "engines": {
+                "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+            }
+        },
+        "node_modules/universal-user-agent": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+            "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+        },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+        }
+    },
+    "dependencies": {
+        "@actions/core": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
+            "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+            "requires": {
+                "@actions/http-client": "^2.0.1",
+                "uuid": "^8.3.2"
+            }
+        },
         "@actions/exec": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.0.tgz",
-            "integrity": "sha512-LImpN9AY0J1R1mEYJjVJfSZWU4zYOlEcwSTgPve1rFQqK5AwrEs6uWW5Rv70gbDIQIAUwI86z6B+9mPK4w9Sbg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+            "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
             "requires": {
                 "@actions/io": "^1.0.1"
             }
         },
         "@actions/github": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
-            "integrity": "sha512-QvE9eAAfEsS+yOOk0cylLBIO/d6WyWIOvsxxzdrPFaud39G6BOkUwScXZn1iBzQzHyu9SBkkLSWlohDWdsasAQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+            "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
             "requires": {
-                "@actions/http-client": "^1.0.11",
-                "@octokit/core": "^3.4.0",
-                "@octokit/plugin-paginate-rest": "^2.13.3",
-                "@octokit/plugin-rest-endpoint-methods": "^5.1.1"
+                "@actions/http-client": "^2.0.1",
+                "@octokit/core": "^3.6.0",
+                "@octokit/plugin-paginate-rest": "^2.17.0",
+                "@octokit/plugin-rest-endpoint-methods": "^5.13.0"
             }
         },
         "@actions/http-client": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
-            "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.1.1.tgz",
+            "integrity": "sha512-qhrkRMB40bbbLo7gF+0vu+X+UawOvQQqNAA/5Unx774RS8poaOhThDOG6BGmxvAnxhQnDp2BG/ZUm65xZILTpw==",
             "requires": {
-                "tunnel": "0.0.6"
+                "tunnel": "^0.0.6"
             }
         },
         "@actions/io": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
-            "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+            "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q=="
         },
         "@octokit/auth-token": {
             "version": "2.5.0",
@@ -64,13 +319,13 @@
             }
         },
         "@octokit/core": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
-            "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+            "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
             "requires": {
                 "@octokit/auth-token": "^2.4.4",
                 "@octokit/graphql": "^4.5.8",
-                "@octokit/request": "^5.6.0",
+                "@octokit/request": "^5.6.3",
                 "@octokit/request-error": "^2.0.5",
                 "@octokit/types": "^6.0.3",
                 "before-after-hook": "^2.2.0",
@@ -98,37 +353,37 @@
             }
         },
         "@octokit/openapi-types": {
-            "version": "11.2.0",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
-            "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
+            "version": "12.11.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+            "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
         },
         "@octokit/plugin-paginate-rest": {
-            "version": "2.17.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
-            "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
+            "version": "2.21.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+            "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
             "requires": {
-                "@octokit/types": "^6.34.0"
+                "@octokit/types": "^6.40.0"
             }
         },
         "@octokit/plugin-rest-endpoint-methods": {
-            "version": "5.13.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
-            "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
+            "version": "5.16.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+            "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
             "requires": {
-                "@octokit/types": "^6.34.0",
+                "@octokit/types": "^6.39.0",
                 "deprecation": "^2.3.1"
             }
         },
         "@octokit/request": {
-            "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.2.tgz",
-            "integrity": "sha512-je66CvSEVf0jCpRISxkUcCa0UkxmFs6eGDRSbfJtAVwbLH5ceqF+YEyC8lj8ystKyZTy8adWr0qmkY52EfOeLA==",
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+            "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
             "requires": {
                 "@octokit/endpoint": "^6.0.1",
                 "@octokit/request-error": "^2.1.0",
                 "@octokit/types": "^6.16.1",
                 "is-plain-object": "^5.0.0",
-                "node-fetch": "^2.6.1",
+                "node-fetch": "^2.6.7",
                 "universal-user-agent": "^6.0.0"
             }
         },
@@ -143,23 +398,23 @@
             }
         },
         "@octokit/types": {
-            "version": "6.34.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
-            "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
+            "version": "6.41.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+            "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
             "requires": {
-                "@octokit/openapi-types": "^11.2.0"
+                "@octokit/openapi-types": "^12.11.0"
             }
         },
         "@vercel/ncc": {
-            "version": "0.32.0",
-            "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.32.0.tgz",
-            "integrity": "sha512-S/SxTHHTbBQSOutpgnqEn+LyTfZcq9xMRAnzY05HpGVjxjmfmvg6SWZZkbW/GJIFznMmHGeGOrI1MEBD7efIkA==",
+            "version": "0.38.0",
+            "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.0.tgz",
+            "integrity": "sha512-B4YKZMm/EqMptKSFyAq4q2SlgJe+VCmEH6Y8gf/E1pTlWbsUJpuH1ymik2Ex3aYO5mCWwV1kaSYHSQOT8+4vHA==",
             "dev": true
         },
         "before-after-hook": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
-            "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
         },
         "deprecation": {
             "version": "2.3.1",
@@ -172,9 +427,9 @@
             "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
         },
         "node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "requires": {
                 "whatwg-url": "^5.0.0"
             }
@@ -182,15 +437,20 @@
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "requires": {
                 "wrappy": "1"
             }
         },
+        "shell-quote": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+            "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA=="
+        },
         "tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
         "tunnel": {
             "version": "0.0.6",
@@ -210,12 +470,12 @@
         "webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
         },
         "whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
             "requires": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -224,7 +484,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fn-pylint-action",
-    "version": "1.1.3",
+    "version": "2.0.0",
     "description": "Run pylint as a GitHub action",
     "main": "dist/index.js",
     "scripts": {
@@ -10,7 +10,8 @@
     "dependencies": {
         "@actions/core": "^1.9.1",
         "@actions/exec": "^1.1.0",
-        "@actions/github": "^5.0.0"
+        "@actions/github": "^5.0.0",
+        "shell-quote": "^1.8.1"
     },
     "devDependencies": {
         "@vercel/ncc": "*"


### PR DESCRIPTION
Supporting only a restricted set of Pylint command-line arguments means less customisation is available to consumers, in return for a small saving on boilerplate.

In particular, new features added to Pylint may be available on some consumers and not others (i.e. running different Pylint versions), meaning we have to support a particular subset of command-line arguments compatible with a specific version range.

A specific example is the `--recursive` flag that is available as of Pylint v2.13.5.

So eschew a fine-grained subset of command-line arguments and instead allow consumers to pass whatever arguments to Pylint they like.

Hence add `shell-quote` as a new dependency, for use in properly splitting the arguments string for use in a subprocess call.